### PR TITLE
Add concurrency option

### DIFF
--- a/hammer_cli_foreman_ssh.gemspec
+++ b/hammer_cli_foreman_ssh.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hammer_cli', '>= 0.0.6'
   s.add_dependency 'hammer_cli_foreman'
-  s.add_dependency 'net-ssh-multi'
+  s.add_dependency 'net-ssh-multi', '>= 1.2.1'
 end

--- a/lib/hammer_cli_foreman_ssh/ssh.rb
+++ b/lib/hammer_cli_foreman_ssh/ssh.rb
@@ -12,6 +12,9 @@ module HammerCLIForemanSsh
 
     command_name 'SSH to hosts'
     option %w(-c --command), 'COMMAND', _('Command to execute'), :attribute_name => :command, :required => true
+    option %w(-n --concurrent), 'CONCURRENCY', _('Number of concurrent SSH sessions'), :attribute_name => :concurrent do |o|
+      Integer(o)
+    end
     option %w(-u --user), 'USER', _('Execute as user'), :attribute_name => :user, :default => ENV['USER']
     option %w(-s --search), 'FILTER', _('Filter hosts based on a filter'), :attribute_name => :search
     option '--[no-]dns', :flag, _('Use DNS to resolve IP addresses'), :attribute_name => :use_dns
@@ -28,6 +31,8 @@ module HammerCLIForemanSsh
     end
 
     def execute
+      signal_usage_error(_("specify 1 or more concurrent hosts")) if (!concurrent.nil? && concurrent < 1)
+
       puts _("About to execute: #{command} as user #{user}\n" +
       "on the following #{hosts.size} hosts: #{host_names.join(', ')}")
 
@@ -39,7 +44,8 @@ module HammerCLIForemanSsh
       ssh_options = { :user => user, :auth_methods => ['publickey'] }
       ssh_options[:keys] = [identity_file] unless identity_file.to_s.empty?
 
-      Net::SSH::Multi.start(:on_error => :warn) do |session|
+      Net::SSH::Multi.start(:concurrent_connections => concurrent, :on_error => :warn) do |session|
+        logger.info(_("executing on #{concurrent} concurrent host(s)")) if concurrent.to_i > 0
         targets.each { |s| session.use s, ssh_options }
         session.exec command
         session.loop


### PR DESCRIPTION
Adding concurrency option to control the number of concurrent hosts that SSH is run on.