### PR TITLE
move module to correct namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
-gem 'gettext', '~> 2.0'
-
-group :test do
-  gem 'rake', '~> 10.1.0'
-  gem 'thor'
-  gem 'minitest', '4.7.4'
-  gem 'minitest-spec-context'
-  gem 'simplecov', '< 0.9.0' # 0.9.0 is not compatible with Ruby 1.8.x
-  gem 'mocha'
-  gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
-end
-
-# load local gemfile
-local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
-self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hammer CLI - Foreman SSH
 ========================
 
-the plugin for hammer
+SSH plugin for hammer
 
 Install
 -------

--- a/hammer_cli_foreman_ssh.gemspec
+++ b/hammer_cli_foreman_ssh.gemspec
@@ -1,10 +1,9 @@
-$:.unshift File.expand_path("../lib", __FILE__)
-require "hammer_cli_foreman/ssh/version"
+require File.expand_path('../lib/hammer_cli_foreman_ssh/version', __FILE__)
 
 Gem::Specification.new do |s|
 
   s.name = "hammer_cli_foreman_ssh"
-  s.version = HammerCLIForeman::SSH.version.dup
+  s.version = HammerCLIForemanSsh.version.dup
   s.platform = Gem::Platform::RUBY
   s.authors = ["Ohad Levy"]
   s.license = 'GPLv3+'

--- a/lib/hammer_cli_foreman/ssh/version.rb
+++ b/lib/hammer_cli_foreman/ssh/version.rb
@@ -1,7 +1,0 @@
-module HammerCLIForeman
-  module SSH
-    def self.version
-      @version ||= Gem::Version.new '0.0.2'
-    end
-  end
-end

--- a/lib/hammer_cli_foreman_ssh.rb
+++ b/lib/hammer_cli_foreman_ssh.rb
@@ -1,3 +1,5 @@
-module HammerCLIForeman
+require 'hammer_cli_foreman'
+module HammerCLIForemanSsh
+  require 'hammer_cli_foreman_ssh/ssh'
+  require 'hammer_cli_foreman_ssh/version'
 end
-require 'hammer_cli_foreman/ssh'

--- a/lib/hammer_cli_foreman_ssh/ssh.rb
+++ b/lib/hammer_cli_foreman_ssh/ssh.rb
@@ -2,7 +2,7 @@ require 'hammer_cli'
 require 'hammer_cli_foreman/host'
 require 'net/ssh/multi'
 
-module HammerCLIForeman::SSH
+module HammerCLIForemanSsh
   class Command < HammerCLIForeman::Command
 
     DEFAULT_PER_PAGE = 1000
@@ -72,5 +72,5 @@ module HammerCLIForeman::SSH
 
   end
 
-  HammerCLIForeman::Host.subcommand('ssh', _('Remote execution via SSH to selected hosts'), HammerCLIForeman::SSH::Command)
+  HammerCLIForeman::Host.subcommand('ssh', _('Remote execution via SSH to selected hosts'), HammerCLIForemanSsh::Command)
 end

--- a/lib/hammer_cli_foreman_ssh/version.rb
+++ b/lib/hammer_cli_foreman_ssh/version.rb
@@ -1,0 +1,5 @@
+module HammerCLIForemanSsh
+  def self.version
+    @version ||= Gem::Version.new '0.0.3'
+  end
+end


### PR DESCRIPTION
and other minor cleanups (also, bump version to 0.0.3)

closes GH-6